### PR TITLE
Seandroid: Add policy for dts configurator and notifier nodes

### DIFF
--- a/common/dtsconfigurator.te
+++ b/common/dtsconfigurator.te
@@ -1,0 +1,8 @@
+type dtsconfigurator, domain;
+type dtsconfigurator_exec, exec_type, file_type;
+
+#started by init
+init_daemon_domain(dtsconfigurator)
+
+allow dtsconfigurator audio_device:dir r_dir_perms;
+allow dtsconfigurator audio_device:chr_file rw_file_perms;

--- a/common/file.te
+++ b/common/file.te
@@ -109,3 +109,6 @@ type mmi_data_file, file_type, data_file_type;
 # hbtp config file
 type hbtp_cfg_file, file_type;
 type hbtp_log_file, file_type;
+
+# dts notifier files
+type dts_data_file, file_type, data_file_type;

--- a/common/file_contexts
+++ b/common/file_contexts
@@ -164,6 +164,7 @@
 /system/bin/gpsone_daemon                       u:object_r:location_exec:s0
 /system/vendor/bin/slim_ap_daemon               u:object_r:location_exec:s0
 /system/bin/energy-awareness                    u:object_r:energyawareness_exec:s0
+/system/bin/dts_configurator                    u:object_r:dtsconfigurator_exec:s0
 /system/vendor/bin/qti                          u:object_r:qti_exec:s0
 /system/bin/wcnss_service                       u:object_r:wcnss_service_exec:s0
 /system/vendor/bin/hbtp_daemon                  u:object_r:hbtp_exec:s0
@@ -233,6 +234,7 @@
 /data/FTM_AP(/.*)?                                                  u:object_r:mmi_data_file:s0
 /data/misc/hbtp(/.*)?                                               u:object_r:hbtp_log_file:s0
 /data/misc/qlogd(/.*)?                                              u:object_r:qlogd_data_file:s0
+/data/misc/dts(/.*)?                                                u:object_r:dts_data_file:s0
 
 ###################################
 # persist files

--- a/common/mediaserver.te
+++ b/common/mediaserver.te
@@ -22,6 +22,11 @@ userdebug_or_eng(`
 allow mediaserver sysfs_esoc:dir r_dir_perms;
 allow mediaserver sysfs_esoc:lnk_file read;
 allow mediaserver system_app_data_file:file rw_file_perms;
+
+# allow mediaserver to write DTS files
+allow mediaserver dts_data_file:dir rw_dir_perms;
+allow mediaserver dts_data_file:file create_file_perms;
+
 # access to perflock
 allow mediaserver mpctl_socket:dir r_dir_perms;
 unix_socket_send(mediaserver, mpctl, mpdecision)

--- a/common/system_app.te
+++ b/common/system_app.te
@@ -30,6 +30,10 @@ allow system_app bluetooth:unix_stream_socket ioctl;
 # access to tee domain
 allow system_app tee:unix_dgram_socket sendto;
 
+# system app to access DTS data files
+allow system_app dts_data_file:dir r_dir_perms;
+allow system_app dts_data_file:file r_file_perms;
+
 # access to time_daemon
 allow system_app time_daemon:unix_stream_socket connectto;
 

--- a/sepolicy.mk
+++ b/sepolicy.mk
@@ -88,6 +88,7 @@ BOARD_SEPOLICY_UNION += \
        mediaserver_test.te \
        energyawareness.te \
        hbtp.te \
+       dtsconfigurator.te \
        vold.te
 
 -include device/qcom/sepolicy/$(TARGET_BOARD_PLATFORM)/Android.mk


### PR DESCRIPTION
Add policy for dts configurator service and notifier nodes.

Change-Id: I9a7909dcfb8afff91f7a52e39393f637845896c5
CRs-fixed: 780001